### PR TITLE
Simplify image output syntax from fenced blocks to inline markdown

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -158,7 +158,7 @@ func TestBuildImage(t *testing.T) {
 	if !strings.Contains(s, "```bash {image}") {
 		t.Errorf("expected image code block in file, got: %s", s)
 	}
-	if !strings.Contains(s, "```output-image") {
-		t.Errorf("expected output-image block in file, got: %s", s)
+	if !strings.Contains(s, "![") {
+		t.Errorf("expected image output in file, got: %s", s)
 	}
 }

--- a/markdown/parser_test.go
+++ b/markdown/parser_test.go
@@ -70,7 +70,7 @@ func TestParseCodeAndOutput(t *testing.T) {
 }
 
 func TestParseImageCodeAndOutput(t *testing.T) {
-	input := "```bash {image}\npython screenshot.py\n```\n\n```output-image\n![Screenshot](abc-2026-02-06.png)\n```\n"
+	input := "```bash {image}\npython screenshot.py\n```\n\n![Screenshot](abc-2026-02-06.png)\n"
 	blocks, err := Parse(strings.NewReader(input))
 	if err != nil {
 		t.Fatal(err)

--- a/markdown/writer.go
+++ b/markdown/writer.go
@@ -39,7 +39,7 @@ func writeBlock(w io.Writer, block Block) error {
 		_, err := fmt.Fprintf(w, "```output\n%s```\n", b.Content)
 		return err
 	case ImageOutputBlock:
-		_, err := fmt.Fprintf(w, "```output-image\n![%s](%s)\n```\n", b.AltText, b.Filename)
+		_, err := fmt.Fprintf(w, "![%s](%s)\n", b.AltText, b.Filename)
 		return err
 	default:
 		return fmt.Errorf("unknown block type: %T", block)

--- a/markdown/writer_test.go
+++ b/markdown/writer_test.go
@@ -61,7 +61,7 @@ func TestWriteImageCodeAndOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "```bash {image}\npython screenshot.py\n```\n\n```output-image\n![Screenshot](abc-2026-02-06.png)\n```\n"
+	expected := "```bash {image}\npython screenshot.py\n```\n\n![Screenshot](abc-2026-02-06.png)\n"
 	if buf.String() != expected {
 		t.Errorf("expected:\n%q\ngot:\n%q", expected, buf.String())
 	}


### PR DESCRIPTION
> I got this in the markdown:
>
> ```
> uv run shot-scraper https://example.com/ -o demo/basic.png 2>&1 && echo demo/basic.png
>
> ![977dd76d-2026-02-06](977dd76d-2026-02-06.png)
> ```
> That's no good, the output image should NOT be a fenced code block because it is actually meant to render



## Summary
This PR simplifies the markdown syntax for image outputs by removing the `output-image` fenced code block format and replacing it with standard inline markdown image syntax (`![alt](filename)`).

## Changes
- **Parser**: Removed special handling for ` ```output-image` fenced blocks and added support for detecting standalone `![alt](filename)` lines as image output blocks
- **Writer**: Changed `ImageOutputBlock` serialization from fenced block format to plain markdown image syntax
- **Tests**: Updated all test cases to reflect the new simpler syntax
- **Build command**: Updated test assertions to check for `![` instead of ` ```output-image`

## Implementation Details
- Image output lines are now recognized by checking if a line starts with `![` and contains a valid image reference
- The parser stops accumulating commentary text when it encounters an image output line
- The new format is more consistent with standard markdown and reduces unnecessary syntax nesting
- All existing functionality is preserved; only the serialization format has changed

https://gisthost.github.io/?965890e662869140fa2cc48abfe8f746/index.html