### PR TITLE
Include Showboat version in the date line produced by init

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -11,7 +11,7 @@ func TestNote(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -33,7 +33,7 @@ func TestNoteMultiple(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,7 +69,7 @@ func TestExec(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ func TestExecNonZeroExit(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,7 +121,7 @@ func TestImage(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/extract_test.go
+++ b/cmd/extract_test.go
@@ -10,7 +10,7 @@ func TestExtract(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 	if err := Note(file, "Hello world"); err != nil {
@@ -47,7 +47,7 @@ func TestExtractOutputOverride(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,14 +10,14 @@ import (
 
 // Init creates a new showboat document with a title and timestamp.
 // Returns an error if the file already exists.
-func Init(file, title string) error {
+func Init(file, title, version string) error {
 	if _, err := os.Stat(file); err == nil {
 		return fmt.Errorf("file already exists: %s", file)
 	}
 
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	blocks := []markdown.Block{
-		markdown.TitleBlock{Title: title, Timestamp: timestamp},
+		markdown.TitleBlock{Title: title, Timestamp: timestamp, Version: version},
 	}
 
 	f, err := os.Create(file)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -11,7 +11,7 @@ func TestInitCreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	err := Init(file, "My Demo")
+	err := Init(file, "My Demo", "v0.3.0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,6 +28,9 @@ func TestInitCreatesFile(t *testing.T) {
 	if !strings.Contains(s, "T") && !strings.Contains(s, "Z") {
 		t.Error("expected ISO 8601 timestamp")
 	}
+	if !strings.Contains(s, "by Showboat v0.3.0") {
+		t.Errorf("expected version in dateline: %q", s)
+	}
 }
 
 func TestInitErrorsIfExists(t *testing.T) {
@@ -36,7 +39,7 @@ func TestInitErrorsIfExists(t *testing.T) {
 
 	os.WriteFile(file, []byte("existing"), 0644)
 
-	err := Init(file, "My Demo")
+	err := Init(file, "My Demo", "v0.3.0")
 	if err == nil {
 		t.Error("expected error when file exists")
 	}

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -11,7 +11,7 @@ func TestVerifyPasses(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
@@ -32,7 +32,7 @@ func TestVerifyDetectsDrift(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
@@ -71,7 +71,7 @@ func TestVerifyWritesOutput(t *testing.T) {
 	file := filepath.Join(dir, "demo.md")
 	outputFile := filepath.Join(dir, "updated.md")
 
-	if err := Init(file, "Test"); err != nil {
+	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "usage: showboat init <file> <title>")
 			os.Exit(1)
 		}
-		if err := cmd.Init(args[1], args[2]); err != nil {
+		if err := cmd.Init(args[1], args[2], version); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}

--- a/markdown/blocks.go
+++ b/markdown/blocks.go
@@ -9,6 +9,7 @@ type Block interface {
 type TitleBlock struct {
 	Title     string
 	Timestamp string
+	Version   string
 }
 
 func (b TitleBlock) Type() string { return "title" }

--- a/markdown/parser.go
+++ b/markdown/parser.go
@@ -37,13 +37,20 @@ func Parse(r io.Reader) ([]Block, error) {
 			if i < len(lines) && lines[i] == "" {
 				i++
 			}
-			// Parse timestamp: *timestamp*
+			// Parse timestamp: *timestamp* or *timestamp by Showboat version*
 			ts := ""
+			ver := ""
 			if i < len(lines) && strings.HasPrefix(lines[i], "*") && strings.HasSuffix(lines[i], "*") {
-				ts = strings.Trim(lines[i], "*")
+				dateline := strings.Trim(lines[i], "*")
+				if idx := strings.Index(dateline, " by Showboat "); idx != -1 {
+					ts = dateline[:idx]
+					ver = dateline[idx+len(" by Showboat "):]
+				} else {
+					ts = dateline
+				}
 				i++
 			}
-			blocks = append(blocks, TitleBlock{Title: title, Timestamp: ts})
+			blocks = append(blocks, TitleBlock{Title: title, Timestamp: ts, Version: ver})
 			skipSeparator()
 			continue
 		}

--- a/markdown/parser_test.go
+++ b/markdown/parser_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseTitle(t *testing.T) {
-	input := "# My Demo\n\n*2026-02-06T15:30:00Z*\n"
+	input := "# My Demo\n\n*2026-02-06T15:30:00Z by Showboat v0.3.0*\n"
 	blocks, err := Parse(strings.NewReader(input))
 	if err != nil {
 		t.Fatal(err)
@@ -24,10 +24,34 @@ func TestParseTitle(t *testing.T) {
 	if tb.Timestamp != "2026-02-06T15:30:00Z" {
 		t.Errorf("expected timestamp '2026-02-06T15:30:00Z', got %q", tb.Timestamp)
 	}
+	if tb.Version != "v0.3.0" {
+		t.Errorf("expected version 'v0.3.0', got %q", tb.Version)
+	}
+}
+
+func TestParseTitleNoVersion(t *testing.T) {
+	input := "# My Demo\n\n*2026-02-06T15:30:00Z*\n"
+	blocks, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	tb, ok := blocks[0].(TitleBlock)
+	if !ok {
+		t.Fatalf("expected TitleBlock, got %T", blocks[0])
+	}
+	if tb.Timestamp != "2026-02-06T15:30:00Z" {
+		t.Errorf("expected timestamp '2026-02-06T15:30:00Z', got %q", tb.Timestamp)
+	}
+	if tb.Version != "" {
+		t.Errorf("expected empty version, got %q", tb.Version)
+	}
 }
 
 func TestParseCommentary(t *testing.T) {
-	input := "# Demo\n\n*2026-02-06T00:00:00Z*\n\nHello world.\n\nMore text here.\n"
+	input := "# Demo\n\n*2026-02-06T00:00:00Z by Showboat v0.3.0*\n\nHello world.\n\nMore text here.\n"
 	blocks, err := Parse(strings.NewReader(input))
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +175,7 @@ func TestRoundTripWithBackticksInOutput(t *testing.T) {
 }
 
 func TestRoundTrip(t *testing.T) {
-	input := "# Demo\n\n*2026-02-06T00:00:00Z*\n\nLet's begin.\n\n```bash\necho hi\n```\n\n```output\nhi\n```\n\nDone.\n"
+	input := "# Demo\n\n*2026-02-06T00:00:00Z by Showboat v0.3.0*\n\nLet's begin.\n\n```bash\necho hi\n```\n\n```output\nhi\n```\n\nDone.\n"
 	blocks, err := Parse(strings.NewReader(input))
 	if err != nil {
 		t.Fatal(err)

--- a/markdown/writer.go
+++ b/markdown/writer.go
@@ -24,7 +24,11 @@ func Write(w io.Writer, blocks []Block) error {
 func writeBlock(w io.Writer, block Block) error {
 	switch b := block.(type) {
 	case TitleBlock:
-		_, err := fmt.Fprintf(w, "# %s\n\n*%s*\n", b.Title, b.Timestamp)
+		dateline := b.Timestamp
+		if b.Version != "" {
+			dateline += " by Showboat " + b.Version
+		}
+		_, err := fmt.Fprintf(w, "# %s\n\n*%s*\n", b.Title, dateline)
 		return err
 	case CommentaryBlock:
 		_, err := fmt.Fprintf(w, "%s\n", b.Text)

--- a/markdown/writer_test.go
+++ b/markdown/writer_test.go
@@ -8,6 +8,21 @@ import (
 func TestWriteTitle(t *testing.T) {
 	var buf strings.Builder
 	blocks := []Block{
+		TitleBlock{Title: "My Demo", Timestamp: "2026-02-06T15:30:00Z", Version: "v0.3.0"},
+	}
+	err := Write(&buf, blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "# My Demo\n\n*2026-02-06T15:30:00Z by Showboat v0.3.0*\n"
+	if buf.String() != expected {
+		t.Errorf("expected:\n%q\ngot:\n%q", expected, buf.String())
+	}
+}
+
+func TestWriteTitleNoVersion(t *testing.T) {
+	var buf strings.Builder
+	blocks := []Block{
 		TitleBlock{Title: "My Demo", Timestamp: "2026-02-06T15:30:00Z"},
 	}
 	err := Write(&buf, blocks)
@@ -116,7 +131,7 @@ func TestWriteOutputNoBackticks(t *testing.T) {
 func TestWriteFullDocument(t *testing.T) {
 	var buf strings.Builder
 	blocks := []Block{
-		TitleBlock{Title: "Demo", Timestamp: "2026-02-06T00:00:00Z"},
+		TitleBlock{Title: "Demo", Timestamp: "2026-02-06T00:00:00Z", Version: "v0.3.0"},
 		CommentaryBlock{Text: "Let's begin."},
 		CodeBlock{Lang: "bash", Code: "echo hi"},
 		OutputBlock{Content: "hi\n"},
@@ -126,7 +141,7 @@ func TestWriteFullDocument(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "# Demo\n\n*2026-02-06T00:00:00Z*\n\nLet's begin.\n\n```bash\necho hi\n```\n\n```output\nhi\n```\n\nDone.\n"
+	expected := "# Demo\n\n*2026-02-06T00:00:00Z by Showboat v0.3.0*\n\nLet's begin.\n\n```bash\necho hi\n```\n\n```output\nhi\n```\n\nDone.\n"
 	if buf.String() != expected {
 		t.Errorf("expected:\n%q\ngot:\n%q", expected, buf.String())
 	}


### PR DESCRIPTION
The date line now renders as `*timestamp by Showboat version*` so
readers can see which version of the tool created the document.  The
version string flows from main.go (set via ldflags at build time)
through cmd.Init() into the TitleBlock.  The parser round-trips the
new format and still handles old date lines without a version.

https://claude.ai/code/session_0156E2fZMAopaVKxEocPZ8et