### PR TITLE
Fix parseImageInput to handle shell-escaped \! in markdown image refs

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -110,8 +110,13 @@ func Image(file, input, workdir string) error {
 // parseImageInput checks whether input is a markdown image reference
 // (![alt](path)) or a plain file path. It returns the image path and any
 // extracted alt text (empty when the input is a plain path).
+// It also handles the common case where the shell escapes "!" to "\!".
 func parseImageInput(input string) (path, altText string) {
 	trimmed := strings.TrimSpace(input)
+	// Some shells escape "!" to "\!", so strip the leading backslash.
+	if strings.HasPrefix(trimmed, `\![`) {
+		trimmed = trimmed[1:]
+	}
 	if strings.HasPrefix(trimmed, "![") && strings.HasSuffix(trimmed, ")") {
 		// Extract alt text between ![ and ]
 		rest := trimmed[2:]


### PR DESCRIPTION
> ![IMG_2094](https://github.com/user-attachments/assets/d9ba0eb0-674a-4cfb-9562-8e860e055d34)
>
> Recreate and explain the error

Some shells escape `"!"` to `"\!"` even in single-quoted strings, causing
the markdown image reference parser to fail to recognize the `![alt](path)`
syntax. The entire escaped string was then treated as a file path,
producing the error "`image file not found: \![alt text](path)`".

Strip the leading backslash when the input starts with `\![` before
attempting to parse as a markdown image reference.

https://claude.ai/code/session_01BqcPiZ39GE4j4ZhvHVFyZ8