### PR TITLE
Adds --filter option to exec command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -67,7 +67,7 @@ func Exec(opts ExecOpts) (string, int, error) {
 		return "", exitCode, err
 	}
 
-	codeBlock := markdown.CodeBlock{Lang: opts.Lang, Code: opts.Code}
+	codeBlock := markdown.CodeBlock{Lang: opts.Lang, Code: opts.Code, Filter: opts.Filter}
 	outputBlock := markdown.OutputBlock{Content: output}
 	blocks = append(blocks, codeBlock, outputBlock)
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,12 +33,22 @@ func Note(file, text string) error {
 
 // Exec appends a code block, executes it, and appends the output.
 // It returns the captured output, the process exit code, and any error.
-func Exec(file, lang, code, workdir string) (string, int, error) {
+// When filter is non-empty the code is passed to the filter via stdin rather
+// than being executed directly; the code block in the report still shows the
+// original lang and code, hiding the filter invocation from the output.
+func Exec(file, lang, code, filter, workdir string) (string, int, error) {
 	if _, err := os.Stat(file); err != nil {
 		return "", 1, fmt.Errorf("file not found: %s", file)
 	}
 
-	output, exitCode, err := execpkg.Run(lang, code, workdir)
+	var output string
+	var exitCode int
+	var err error
+	if filter != "" {
+		output, exitCode, err = execpkg.RunWithFilter(filter, code, workdir)
+	} else {
+		output, exitCode, err = execpkg.Run(lang, code, workdir)
+	}
 	if err != nil {
 		return "", exitCode, fmt.Errorf("running code: %w", err)
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -31,38 +31,47 @@ func Note(file, text string) error {
 	return nil
 }
 
+// ExecOpts configures an Exec invocation.
+type ExecOpts struct {
+	File    string // path to the showboat document
+	Lang    string // language label for the code block
+	Code    string // code to execute (or pipe to filter)
+	Filter  string // if non-empty, pipe code to this shell command instead of executing directly
+	Workdir string // working directory; empty means current directory
+}
+
 // Exec appends a code block, executes it, and appends the output.
 // It returns the captured output, the process exit code, and any error.
-// When filter is non-empty the code is passed to the filter via stdin rather
+// When Filter is non-empty the code is passed to the filter via stdin rather
 // than being executed directly; the code block in the report still shows the
 // original lang and code, hiding the filter invocation from the output.
-func Exec(file, lang, code, filter, workdir string) (string, int, error) {
-	if _, err := os.Stat(file); err != nil {
-		return "", 1, fmt.Errorf("file not found: %s", file)
+func Exec(opts ExecOpts) (string, int, error) {
+	if _, err := os.Stat(opts.File); err != nil {
+		return "", 1, fmt.Errorf("file not found: %s", opts.File)
 	}
 
 	var output string
 	var exitCode int
 	var err error
-	if filter != "" {
-		output, exitCode, err = execpkg.RunWithFilter(filter, code, workdir)
+	if opts.Filter != "" {
+		output, exitCode, err = execpkg.RunWithFilter(opts.Filter, opts.Code, opts.Workdir)
 	} else {
-		output, exitCode, err = execpkg.Run(lang, code, workdir)
+		output, exitCode, err = execpkg.Run(opts.Lang, opts.Code, opts.Workdir)
 	}
 	if err != nil {
 		return "", exitCode, fmt.Errorf("running code: %w", err)
 	}
 
-	blocks, err := readBlocks(file)
+	blocks, err := readBlocks(opts.File)
 	if err != nil {
 		return "", exitCode, err
 	}
 
-	codeBlock := markdown.CodeBlock{Lang: lang, Code: code}
+	codeBlock := markdown.CodeBlock{Lang: opts.Lang, Code: opts.Code}
 	outputBlock := markdown.OutputBlock{Content: output}
 	blocks = append(blocks, codeBlock, outputBlock)
 
-	if err := writeBlocks(file, blocks); err != nil {
+	if err := writeBlocks(opts.File, blocks); err != nil {
 		return output, exitCode, err
 	}
 

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -112,8 +112,8 @@ func TestExecWithFilter(t *testing.T) {
 	}
 
 	s := string(content)
-	if !strings.Contains(s, "```python\n1 + 1\n```") {
-		t.Errorf("expected python code block in file, got: %s", s)
+	if !strings.Contains(s, "```python {filter=bash -c 'echo result: $(cat)'}\n1 + 1\n```") {
+		t.Errorf("expected python code block with filter attribute in file, got: %s", s)
 	}
 	if !strings.Contains(s, "```output\nresult: 1 + 1\n```") {
 		t.Errorf("expected output block with filter output in file, got: %s", s)

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -76,7 +76,7 @@ func TestExec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,6 +94,32 @@ func TestExec(t *testing.T) {
 	}
 }
 
+func TestExecWithFilter(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "demo.md")
+
+	if err := Init(file, "Test", "dev"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := Exec(file, "python", "1 + 1", "bash -c 'echo result: $(cat)'", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "```python\n1 + 1\n```") {
+		t.Errorf("expected python code block in file, got: %s", s)
+	}
+	if !strings.Contains(s, "```output\nresult: 1 + 1\n```") {
+		t.Errorf("expected output block with filter output in file, got: %s", s)
+	}
+}
+
 func TestExecNonZeroExit(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")
@@ -102,7 +128,7 @@ func TestExecNonZeroExit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := Exec(file, "bash", "echo failing && exit 1", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo failing && exit 1", "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -248,7 +274,7 @@ func TestExecCallsRemotePost(t *testing.T) {
 	}
 
 	gotBody = ""
-	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -76,7 +76,7 @@ func TestExec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo hello"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +102,7 @@ func TestExecWithFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := Exec(file, "python", "1 + 1", "bash -c 'echo result: $(cat)'", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "python", Code: "1 + 1", Filter: "bash -c 'echo result: $(cat)'"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +128,7 @@ func TestExecNonZeroExit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := Exec(file, "bash", "echo failing && exit 1", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo failing && exit 1"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -274,7 +274,7 @@ func TestExecCallsRemotePost(t *testing.T) {
 	}
 
 	gotBody = ""
-	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo hello"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/extract_test.go
+++ b/cmd/extract_test.go
@@ -16,7 +16,7 @@ func TestExtract(t *testing.T) {
 	if err := Note(file, "Hello world"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/extract_test.go
+++ b/cmd/extract_test.go
@@ -16,7 +16,7 @@ func TestExtract(t *testing.T) {
 	if err := Note(file, "Hello world"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo hello"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -42,7 +42,12 @@ func Verify(file, outputFile, workdir string) ([]Diff, error) {
 		}
 
 		// Execute the code block
-		output, _, err := execpkg.Run(cb.Lang, cb.Code, workdir)
+		var output string
+		if cb.Filter != "" {
+			output, _, err = execpkg.RunWithFilter(cb.Filter, cb.Code, workdir)
+		} else {
+			output, _, err = execpkg.Run(cb.Lang, cb.Code, workdir)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("executing block %d: %w", i, err)
 		}

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -14,7 +14,7 @@ func TestVerifyPasses(t *testing.T) {
 	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func TestVerifyDetectsDrift(t *testing.T) {
 	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,7 +74,7 @@ func TestVerifyWritesOutput(t *testing.T) {
 	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", ""); err != nil {
+	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -14,7 +14,7 @@ func TestVerifyPasses(t *testing.T) {
 	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo hello"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -35,7 +35,7 @@ func TestVerifyDetectsDrift(t *testing.T) {
 	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo hello"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,7 +74,7 @@ func TestVerifyWritesOutput(t *testing.T) {
 	if err := Init(file, "Test", "dev"); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := Exec(file, "bash", "echo hello", "", ""); err != nil {
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "bash", Code: "echo hello"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -66,6 +66,27 @@ func TestVerifyDetectsDrift(t *testing.T) {
 	}
 }
 
+func TestVerifyWithFilter(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "demo.md")
+
+	if err := Init(file, "Test", "dev"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Exec(ExecOpts{File: file, Lang: "python", Code: "hello\n", Filter: "cat"}); err != nil {
+		t.Fatal(err)
+	}
+
+	diffs, err := Verify(file, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %d: %v", len(diffs), diffs)
+	}
+}
+
 func TestVerifyWritesOutput(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "demo.md")

--- a/exec/runner.go
+++ b/exec/runner.go
@@ -4,20 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
-// Run executes code using the given language interpreter and returns
-// the combined stdout+stderr output and the process exit code.
-// Non-zero exit codes are not treated as errors — the output is still
-// captured and returned alongside the exit code.
-// If workdir is empty, the current directory is used.
-func Run(lang, code, workdir string) (string, int, error) {
-	cmd := exec.Command(lang, "-c", code)
-
-	if workdir != "" {
-		cmd.Dir = workdir
-	}
-
+// runCmd runs cmd, capturing combined stdout+stderr. Non-zero exit codes are
+// not treated as errors — the output is still returned alongside the exit code.
+func runCmd(cmd *exec.Cmd, label string) (string, int, error) {
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
@@ -27,8 +19,34 @@ func Run(lang, code, workdir string) (string, int, error) {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return buf.String(), exitErr.ExitCode(), nil
 		}
-		return "", 1, fmt.Errorf("executing %s: %w", lang, err)
+		return "", 1, fmt.Errorf("executing %s: %w", label, err)
 	}
 
 	return buf.String(), 0, nil
+}
+
+// Run executes code using the given language interpreter and returns
+// the combined stdout+stderr output and the process exit code.
+// Non-zero exit codes are not treated as errors — the output is still
+// captured and returned alongside the exit code.
+// If workdir is empty, the current directory is used.
+func Run(lang, code, workdir string) (string, int, error) {
+	cmd := exec.Command(lang, "-c", code)
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	return runCmd(cmd, lang)
+}
+
+// RunWithFilter executes filter (a shell command string) with code written to
+// its stdin, and returns the combined stdout+stderr output and exit code.
+// The filter is run via "bash -c". If workdir is empty, the current directory
+// is used.
+func RunWithFilter(filter, code, workdir string) (string, int, error) {
+	cmd := exec.Command("bash", "-c", filter)
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	cmd.Stdin = strings.NewReader(code)
+	return runCmd(cmd, "filter")
 }

--- a/exec/runner_test.go
+++ b/exec/runner_test.go
@@ -77,3 +77,46 @@ func TestRunStderrCaptured(t *testing.T) {
 		t.Errorf("expected both 'out' and 'err' in output, got %q", output)
 	}
 }
+
+func TestRunWithFilter(t *testing.T) {
+	output, exitCode, err := RunWithFilter("cat", "hello from stdin", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", exitCode)
+	}
+	if output != "hello from stdin" {
+		t.Errorf("expected 'hello from stdin', got %q", output)
+	}
+}
+
+func TestRunWithFilterTransforms(t *testing.T) {
+	output, _, err := RunWithFilter("tr a-z A-Z", "hello", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "HELLO" {
+		t.Errorf("expected 'HELLO', got %q", output)
+	}
+}
+
+func TestRunWithFilterNonZeroExit(t *testing.T) {
+	_, exitCode, err := RunWithFilter("bash -c 'cat; exit 3'", "data", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 3 {
+		t.Errorf("expected exit code 3, got %d", exitCode)
+	}
+}
+
+func TestRunWithFilterWorkdir(t *testing.T) {
+	output, _, err := RunWithFilter("bash -c 'cat; pwd'", "input\n", "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "/tmp") {
+		t.Errorf("expected /tmp in output, got %q", output)
+	}
+}

--- a/help.txt
+++ b/help.txt
@@ -8,7 +8,7 @@ code blocks and confirm the outputs still match.
 Usage:
   showboat init <file> <title>             Create a new demo document
   showboat note <file> [text]              Append commentary (text or stdin)
-  showboat exec <file> <lang> [code]       Run code and capture output
+  showboat exec <file> <lang> [--filter <cmd>] [code]  Run code and capture output
   showboat image <file> <path>             Copy image into document
   showboat image <file> '![alt](path)'   Copy image with alt text
   showboat pop <file>                      Remove the most recent entry
@@ -30,6 +30,19 @@ Exec output:
     hello
     $ echo $?
     1
+
+Exec filter:
+  The --filter option pipes the code to an external command via stdin instead
+  of executing it directly. The code block in the report still shows the
+  original lang and code; the filter invocation is hidden. This is useful when
+  the execution mechanism is incidental — for example, evaluating Python code
+  via a Jupyter kernel where the report should show clean Python, not the
+  tool invocation:
+
+    $ showboat exec demo.md python --filter "jupyter-kernel-eval" "1 + 1"
+
+  The report gets a python code block containing "1 + 1" and an output
+  block containing the result. jupyter-kernel-eval never appears in the document.
 
 Image:
   The "image" command accepts a path to an image file or a markdown image

--- a/main.go
+++ b/main.go
@@ -75,7 +75,13 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
-		output, exitCode, err := cmd.Exec(execFile, execLang, code, execFilter, workdir)
+		output, exitCode, err := cmd.Exec(cmd.ExecOpts{
+			File:    execFile,
+			Lang:    execLang,
+			Code:    code,
+			Filter:  execFilter,
+			Workdir: workdir,
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -55,15 +55,27 @@ func main() {
 
 	case "exec":
 		if len(args) < 3 {
-			fmt.Fprintln(os.Stderr, "usage: showboat exec <file> <lang> [code]")
+			fmt.Fprintln(os.Stderr, "usage: showboat exec <file> <lang> [--filter <cmd>] [code]")
 			os.Exit(1)
 		}
-		code, err := getTextArg(args[3:])
+		execFile := args[1]
+		execLang := args[2]
+		execFilter := ""
+		var execRest []string
+		for i := 3; i < len(args); i++ {
+			if args[i] == "--filter" && i+1 < len(args) {
+				execFilter = args[i+1]
+				i++ // skip the filter value
+			} else {
+				execRest = append(execRest, args[i])
+			}
+		}
+		code, err := getTextArg(execRest)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
-		output, exitCode, err := cmd.Exec(args[1], args[2], code, workdir)
+		output, exitCode, err := cmd.Exec(execFile, execLang, code, execFilter, workdir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)

--- a/markdown/blocks.go
+++ b/markdown/blocks.go
@@ -27,6 +27,7 @@ type CodeBlock struct {
 	Lang    string
 	Code    string
 	IsImage bool
+	Filter  string // if non-empty, code is piped to this shell command instead of executed directly
 }
 
 func (b CodeBlock) Type() string { return "code" }

--- a/markdown/parser.go
+++ b/markdown/parser.go
@@ -89,12 +89,20 @@ func Parse(r io.Reader) ([]Block, error) {
 				blocks = append(blocks, OutputBlock{Content: content.String()})
 
 			default:
-				// Code block. Check for {image} suffix.
+				// Code block. Extract {image} and {filter=...} suffixes.
 				lang := info
 				isImage := false
+				filter := ""
 				if strings.HasSuffix(lang, " {image}") {
 					lang = strings.TrimSuffix(lang, " {image}")
 					isImage = true
+				}
+				if idx := strings.Index(lang, " {filter="); idx != -1 {
+					suffix := lang[idx+len(" {filter="):]
+					if end := strings.Index(suffix, "}"); end != -1 {
+						filter = suffix[:end]
+						lang = lang[:idx] + suffix[end+1:]
+					}
 				}
 				var codeLines []string
 				for i < len(lines) && lines[i] != closingFence {
@@ -106,6 +114,7 @@ func Parse(r io.Reader) ([]Block, error) {
 					Lang:    lang,
 					Code:    strings.Join(codeLines, "\n"),
 					IsImage: isImage,
+					Filter:  filter,
 				})
 			}
 

--- a/markdown/writer.go
+++ b/markdown/writer.go
@@ -42,6 +42,9 @@ func writeBlock(w io.Writer, block Block) error {
 		return err
 	case CodeBlock:
 		lang := b.Lang
+		if b.Filter != "" {
+			lang += " {filter=" + b.Filter + "}"
+		}
 		if b.IsImage {
 			lang += " {image}"
 		}

--- a/markdown/writer_test.go
+++ b/markdown/writer_test.go
@@ -82,6 +82,22 @@ func TestWriteImageCodeAndOutput(t *testing.T) {
 	}
 }
 
+func TestWriteCodeWithFilter(t *testing.T) {
+	var buf strings.Builder
+	blocks := []Block{
+		CodeBlock{Lang: "python", Code: "1 + 1", Filter: "jupyter-kernel-eval"},
+		OutputBlock{Content: "2\n"},
+	}
+	err := Write(&buf, blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "```python {filter=jupyter-kernel-eval}\n1 + 1\n```\n\n```output\n2\n```\n"
+	if buf.String() != expected {
+		t.Errorf("expected:\n%q\ngot:\n%q", expected, buf.String())
+	}
+}
+
 func TestWriteOutputWithTripleBackticks(t *testing.T) {
 	var buf strings.Builder
 	blocks := []Block{


### PR DESCRIPTION
Adds a `--filter` option to the exec command, this pipes the code to an
external command via stdin instead of executing it directly. The code block in
the report still shows the original language and code; the filter invocation is
hidden. This is useful when the execution mechanism is incidental - for
example, evaluating Python code via a Jupyter kernel where the report should
show clean Python, not the tool invocation:

    $ showboat exec demo.md python --filter "jupyter-kernel-eval" "1 + 1"

It is also useful when the language name for the code block is
different to the program that evaluates the code:

    $ showboat exec demo.md python --filter "python3.15" "print(1 + 1)"
  
Or if the program doesn't support `-c` 

    $ showboat exec demo.md javascript --filter "node -" "console.log('hi hi')"

The filter used is stored in the report as an attribute on the code block, so
that the verify command works with filters too.