### PR TITLE
Fix output block closing fence when content lacks trailing newline

### DIFF
--- a/markdown/writer.go
+++ b/markdown/writer.go
@@ -49,7 +49,11 @@ func writeBlock(w io.Writer, block Block) error {
 		return err
 	case OutputBlock:
 		fence := fenceFor(b.Content)
-		_, err := fmt.Fprintf(w, "%soutput\n%s%s\n", fence, b.Content, fence)
+		sep := ""
+		if b.Content != "" && !strings.HasSuffix(b.Content, "\n") {
+			sep = "\n"
+		}
+		_, err := fmt.Fprintf(w, "%soutput\n%s%s%s\n", fence, b.Content, sep, fence)
 		return err
 	case ImageOutputBlock:
 		_, err := fmt.Fprintf(w, "![%s](%s)\n", b.AltText, b.Filename)

--- a/markdown/writer_test.go
+++ b/markdown/writer_test.go
@@ -128,6 +128,21 @@ func TestWriteOutputNoBackticks(t *testing.T) {
 	}
 }
 
+func TestWriteOutputNoTrailingNewline(t *testing.T) {
+	var buf strings.Builder
+	blocks := []Block{
+		OutputBlock{Content: "hello"},
+	}
+	err := Write(&buf, blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "```output\nhello\n```\n"
+	if buf.String() != expected {
+		t.Errorf("expected:\n%q\ngot:\n%q", expected, buf.String())
+	}
+}
+
 func TestWriteTitleWithDocumentID(t *testing.T) {
 	var buf strings.Builder
 	blocks := []Block{


### PR DESCRIPTION
_All the following is generated by CC, but I've read it, and it makes sense to me. Built and tested locally too!_

## Summary
- Commands like `printf "hello"` produce output without a trailing newline, causing the closing ``` fence to land on the same line as the output (`hello```), breaking the resulting markdown
- Added a conditional newline before the closing fence when output content doesn't already end with `\n`
- Added `TestWriteOutputNoTrailingNewline` test case

## Reproduction
```bash
showboat init /tmp/repro.md "Repro"
showboat exec /tmp/repro.md bash 'printf "hello"'
```

**Before:** `hello``` ` (broken markdown)
**After:**
```
hello
```

## Test plan
- [x] `go test ./...` — all existing tests pass
- [x] New test `TestWriteOutputNoTrailingNewline` covers the fix
- [x] Manual verification with `printf "hello"` produces valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)