### PR TITLE
Add shell metacharacter tests and fix error message quoting in exec runner

### DIFF
--- a/exec/runner.go
+++ b/exec/runner.go
@@ -27,7 +27,7 @@ func Run(lang, code, workdir string) (string, int, error) {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return buf.String(), exitErr.ExitCode(), nil
 		}
-		return "", 1, fmt.Errorf("executing %s: %w", lang, err)
+		return "", 1, fmt.Errorf("executing %q: %w", lang, err)
 	}
 
 	return buf.String(), 0, nil

--- a/exec/runner_test.go
+++ b/exec/runner_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -22,6 +23,51 @@ func TestRunPython(t *testing.T) {
 	}
 	if output != "hi\n" {
 		t.Errorf("expected 'hi\\n', got %q", output)
+	}
+}
+
+func TestRunWithPipe(t *testing.T) {
+	output, exitCode, err := Run("bash", "echo hello | wc -l", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit 0, got %d", exitCode)
+	}
+	if strings.TrimSpace(output) != "1" {
+		t.Errorf("expected '1', got %q", output)
+	}
+}
+
+func TestRunWithRedirect(t *testing.T) {
+	dir := t.TempDir()
+	outFile := dir + "/out.txt"
+	_, exitCode, err := Run("bash", "echo redirected > "+outFile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit 0, got %d", exitCode)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != "redirected" {
+		t.Errorf("expected 'redirected' in file, got %q", string(data))
+	}
+}
+
+func TestRunShellMetacharacters(t *testing.T) {
+	output, exitCode, err := Run("sh", "echo one && echo two", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Errorf("expected exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(output, "one") || !strings.Contains(output, "two") {
+		t.Errorf("expected 'one' and 'two' in output, got %q", output)
 	}
 }
 


### PR DESCRIPTION
I was using showboat to build a demo document that needed piped commands — `echo hello | wc -l`, `ls | head -3`, that kind of thing. Nothing special. While reading through the runner code I noticed two things: the existing behaviour for shell metacharacters was already correct (bash/sh/zsh get `-c`, which naturally interprets `|`, `>`, `&&`), but there were no tests proving it. I also spotted the error message using `%s` to format the interpreter name, which produces ambiguous output when the binary name runs up against punctuation.

This PR adds explicit test coverage for the metacharacter cases and tightens the error formatting. No behaviour change to the runner itself.

## Changes

**`exec/runner_test.go`** — three new tests:

- `TestRunWithPipe`: runs `echo hello | wc -l` via bash, asserts exit 0 and output `1`
- `TestRunWithRedirect`: runs `echo redirected > file`, asserts the file was created with the right content
- `TestRunShellMetacharacters`: runs `echo one && echo two` via sh, asserts both lines appear and exit code is 0

All three check exit codes explicitly, not just output content.

**`exec/runner.go`** — one-character change: `%s` → `%q` in the startup-failure error path. Before: `executing python3: exec: "python3": executable file not found`. After: `executing "python3": exec: ...`. The quotes make it unambiguous where the binary name ends and the error begins.

## Evidence of testing

Built the binary locally and ran a full demo document exercising every metacharacter case:

```
$ showboat init /tmp/demo.md "Shell Metacharacter Demo"
$ showboat exec /tmp/demo.md bash "echo 'the quick brown fox' | wc -w"
       4
$ showboat exec /tmp/demo.md bash "echo step1 && echo step2 && echo step3"
step1
step2
step3
$ showboat exec /tmp/demo.md bash "echo 'hello from redirect' > /tmp/out.txt && cat /tmp/out.txt"
hello from redirect
$ showboat exec /tmp/demo.md python3 "print(2 + 2)"
4
$ showboat exec /tmp/demo.md sh "printf 'a\nb\nc\n' | grep b"
b
$ showboat verify /tmp/demo.md
(exit 0 — no diffs)
```

`verify` passing confirms the round-trip: `python3` blocks still execute as Python, not bash. `lang` stays as the actual interpreter.

Full test suite:

```
$ go test ./...
ok  	github.com/simonw/showboat	4.140s
ok  	github.com/simonw/showboat/cmd	0.858s
ok  	github.com/simonw/showboat/exec	0.705s
ok  	github.com/simonw/showboat/markdown	(cached)
```